### PR TITLE
Move function `install_gcloud` to linux.sh

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -19,30 +19,6 @@ function skip_install_message() {
     message "${1} already installed, skipping it"
 }
 
-function install_gcloud() {
-    # WHY: Perhaps it will be useful to linux distro who dont have gcloud package
-    if [ "$(is_installed "gcloud --version")" == "yes" ]; then
-        skip_install_message "gcloud"
-        return
-    fi
-
-    local version="${1}"
-    local os="${2}"
-    local workdir=$(mktemp -d)
-    local installdir="$HOME/.local"
-    local sdkdir="${installdir}/google-cloud-sdk"
-
-    mkdir -p "${installdir}"
-    printf "google cloud SDK will be installed at: %s\n" "${sdkdir}"
-    cd "${workdir}"
-    curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${version}-${os}-x86_64.tar.gz
-    tar zxvf google-cloud-sdk-${version}-${os}-x86_64.tar.gz
-    mv google-cloud-sdk ${installdir}
-    cd ${sdkdir}
-    ./install.sh
-    rm -rf ${workdir}
-}
-
 function fix_git_for_go_get(){
     local gitcfg_path="${HOME}/.gitconfig"
     local hascfg=$(grep "ssh://git@github.com/" "${gitcfg_path}" &>/dev/null && echo "yes" || echo "no")

--- a/linux.sh
+++ b/linux.sh
@@ -1,5 +1,28 @@
 source common.sh
 
+function install_linux_gcloud() {
+    if [ "$(is_installed "gcloud --version")" == "yes" ]; then
+        skip_install_message "gcloud"
+        return
+    fi
+
+    local version="${1}"
+    local os="${2}"
+    local workdir=$(mktemp -d)
+    local installdir="$HOME/.local"
+    local sdkdir="${installdir}/google-cloud-sdk"
+
+    mkdir -p "${installdir}"
+    printf "google cloud SDK will be installed at: %s\n" "${sdkdir}"
+    cd "${workdir}"
+    curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${version}-${os}-x86_64.tar.gz
+    tar zxvf google-cloud-sdk-${version}-${os}-x86_64.tar.gz
+    mv google-cloud-sdk ${installdir}
+    cd ${sdkdir}
+    ./install.sh
+    rm -rf ${workdir}
+}
+
 function bootstrap_linux() {
     echo
     echo "TODO: Install deps, for now just configuration is being done"


### PR DESCRIPTION
This function is Linux specific anyway (in macOS, gcloud is installed
via `brew cask install` [here](https://github.com/fromAtoB/bootstrap/blob/master/macos.sh#L36)).

The function is also renamed to `install_linux_gcloud` in line with the
prevailing convention.

I haven't tested this though :)